### PR TITLE
get python module install path via sysconfig

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -189,7 +189,12 @@ IF(PYTHON_FOUND)
     SET_TARGET_PROPERTIES(pyphotospline PROPERTIES LINK_FLAGS "-undefined dynamic_lookup")
   endif(APPLE)
   EXECUTE_PROCESS (COMMAND ${PYTHON_EXECUTABLE} -c
-    "from distutils.sysconfig import get_python_lib; print(get_python_lib(prefix=''))"
+    "from sysconfig import get_path, get_preferred_scheme; \
+     from pathlib import PurePath; \
+     ps = get_preferred_scheme('prefix'); \
+     d  = PurePath(get_path('data', ps)); \
+     pl = PurePath(get_path('platlib', ps)); \
+     print(pl.relative_to(d))"
     OUTPUT_VARIABLE PYTHON_MODULE_DIR
     OUTPUT_STRIP_TRAILING_WHITESPACE)
   INSTALL(TARGETS pyphotospline LIBRARY DESTINATION ${PYTHON_MODULE_DIR})


### PR DESCRIPTION
distutils is going away in 3.12. use pseudo-official (https://bugs.python.org/issue41282#msg393017) replacement.