### PR TITLE
Enable automatic function multiversioning

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -55,15 +55,50 @@ target_compile_features (photospline
   PUBLIC
     cxx_constexpr
 )
-target_compile_options (photospline PUBLIC -O3)
+target_compile_options (photospline PUBLIC -O3 -fPIC)
 target_compile_options (photospline PRIVATE -Wall -Wextra)
-IF (CMAKE_SYSTEM_PROCESSOR MATCHES "^(i.86|x86_64)$")
-  target_compile_options (photospline PUBLIC -msse2 -msse3 -msse4 -msse4.1 -msse4.2 -mno-avx)
-ELSEIF (CMAKE_SYSTEM_PROCESSOR MATCHES "^(powerpc|ppc)")
-  target_compile_options (photospline PUBLIC -maltivec)
-ELSEIF (CMAKE_SYSTEM_PROCESSOR MATCHES "^sparc")
-  target_compile_options (photospline PUBLIC -mvis)
+
+# For newer compilers we would like to use 'target cloning'/'function multiversioning'
+# to cover different instruction sets portably (using preprocessor logic so that
+# downstream code picks it up 'for free'), but for old compilers which can't do that,
+# we still want to make sure that a reasonable baseline instruction set is used.
+# The logic here may be overridden by manually setting USE_TARGET_CLONING.
+IF (NOT DEFINED USE_TARGET_CLONING)
+  # This logic should mirror what is in include/photospline/detail/simd.h
+  IF (CMAKE_SYSTEM_PROCESSOR MATCHES "^(i.86|x86_64)$")
+    IF (CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+      set(USE_TARGET_CLONING FALSE)
+    ELSEIF (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+      IF (CMAKE_CXX_COMPILER_VERSION VERSION_GREATER 8.3)
+        set(USE_TARGET_CLONING TRUE)
+      ELSE ()
+        set(USE_TARGET_CLONING FALSE)
+      ENDIF ()
+    ELSE ()
+      # Assume other compilers do not support this
+      set(USE_TARGET_CLONING FALSE)
+    ENDIF ()
+  ELSE ()
+    # No detailed treatment of non-x86 architectures at this time
+    set(USE_TARGET_CLONING FALSE)
+  ENDIF()
+ENDIF (NOT DEFINED USE_TARGET_CLONING)
+
+IF (USE_TARGET_CLONING)
+  MESSAGE("-- Will assume use of target cloning for vector instruction sets")
+ELSE ()
+  MESSAGE("-- Will NOT assume use of target cloning for vector instruction sets")
+
+  IF (CMAKE_SYSTEM_PROCESSOR MATCHES "^(i.86|x86_64)$")
+    # explicitly disable AVX to avoid crashing on non-AVX-enabled machines
+    target_compile_options (photospline PUBLIC -msse2 -msse3 -msse4 -msse4.1 -msse4.2 -mno-avx)
+  ELSEIF (CMAKE_SYSTEM_PROCESSOR MATCHES "^(powerpc|ppc)")
+    target_compile_options (photospline PUBLIC -maltivec)
+  ELSEIF (CMAKE_SYSTEM_PROCESSOR MATCHES "^sparc")
+    target_compile_options (photospline PUBLIC -mvis)
+  ENDIF ()
 ENDIF ()
+
 target_link_libraries (photospline
   PUBLIC
     ${CFITSIO_LIBRARIES}

--- a/include/photospline/detail/bspline_multi.h
+++ b/include/photospline/detail/bspline_multi.h
@@ -7,6 +7,7 @@ namespace photospline{
 
 template <typename Alloc>
 template <typename Float>
+PHOTOSPLINE_TARGET_CLONE
 void splinetable<Alloc>::ndsplineeval_multibasis_core(const int *centers, const typename detail::simd_vector<Float>::type*** localbasis, typename detail::simd_vector<Float>::type* result) const{
 #if (defined(__i386__) || defined (__x86_64__)) && defined(__ELF__)
 	/*
@@ -80,6 +81,7 @@ namespace{
 	
 template <typename Alloc>
 template <typename Float, unsigned int D>
+PHOTOSPLINE_TARGET_CLONE
 void splinetable<Alloc>::ndsplineeval_multibasis_coreD(const int *centers, const typename detail::simd_vector<Float>::type*** localbasis, typename detail::simd_vector<Float>::type* result) const{
 #if (defined(__i386__) || defined (__x86_64__)) && defined(__ELF__)
 	/*
@@ -150,6 +152,7 @@ void splinetable<Alloc>::ndsplineeval_multibasis_coreD(const int *centers, const
 
 template <typename Alloc>
 template <typename Float, unsigned int D, unsigned int Order>
+PHOTOSPLINE_TARGET_CLONE
 void splinetable<Alloc>::ndsplineeval_multibasis_coreD_FixedOrder(const int *centers, const typename detail::simd_vector<Float>::type*** localbasis, typename detail::simd_vector<Float>::type* result) const{
 #if (defined(__i386__) || defined (__x86_64__)) && defined(__ELF__)
 	/*
@@ -223,6 +226,7 @@ void splinetable<Alloc>::ndsplineeval_multibasis_coreD_FixedOrder(const int *cen
 
 template <typename Alloc>
 template<typename Float, unsigned int ... Orders>
+PHOTOSPLINE_TARGET_CLONE
 void splinetable<Alloc>::ndsplineeval_multibasis_core_KnownOrder(const int *centers, const typename detail::simd_vector<Float>::type*** localbasis, typename detail::simd_vector<Float>::type* result) const{
 #if (defined(__i386__) || defined (__x86_64__)) && defined(__ELF__)
 	/*
@@ -294,6 +298,7 @@ void splinetable<Alloc>::ndsplineeval_multibasis_core_KnownOrder(const int *cent
 
 template<typename Alloc>
 template<typename Float>
+PHOTOSPLINE_TARGET_CLONE
 void
 splinetable<Alloc>::ndsplineeval_gradient(const double* x, const int* centers, double* evaluates) const
 {
@@ -351,6 +356,7 @@ splinetable<Alloc>::ndsplineeval_gradient(const double* x, const int* centers, d
 
 template<typename Alloc>
 template<typename Float>
+PHOTOSPLINE_TARGET_CLONE
 void splinetable<Alloc>::evaluator_type<Float>::ndsplineeval_gradient(const double* x, const int* centers, double* evaluates) const
 {
 	uint32_t maxdegree = *std::max_element(table.order,table.order+table.ndim) + 1;


### PR DESCRIPTION
For some time, we have disabled the use of AVX instructions when compiling in order to prevent issues (SIGILL) for users who compile on an AVX-capable machione, but then run their programs on a machine which predates those instructions. This makes little difference for single-precision evaluation, but hurts significantly for double-precision evaulation. 

GCC's [function multiversioning](https://gcc.gnu.org/onlinedocs/gcc/Function-Multiversioning.html) feature offers a way to have our cake and eat it too, in the sense of enabling these instructions at runtime only on machines which can use them. Direct us of that feature is annoying, however, as it requires an entire separate function definition for each version. That would makes sense when using vector intrinsics explicitly, but we don't and duplicating code would be ugly. However, the related [target_clones attribute](https://gcc.gnu.org/onlinedocs/gcc/Common-Function-Attributes.html) offers a way to get this done more automatically. 

Testing seems to indicate that this can substantially mitigate the slow-down involved in switching to double-precision evaluation:

'multiple'/full gradient evaluation rate with `photospline-bench-templated`:
(d=double precision evaluation)

```
Table                                                 | SSE 4.2 only | AVX enabled |
------------------------------------------------------+--------------+-------------+
test_spline_3d.fits                                   |   4.85e+06   |   4.77e+06  |
test_spline_3d.fits (d)                               |   3.30e+06   |   4.86e+06  |
test_spline_5d.fits                                   |   7.39e+05   |   7.32e+05  |
test_spline_5d.fits (d)                               |   2.39e+05   |   5.23e+05  |
cascade_single_spice_bfr-v2_flat_z20_a5.prob.fits     |   1.18e+05   |   1.13e+05  |
cascade_single_spice_bfr-v2_flat_z20_a5.prob.fits (d) |   4.21e+04   |   1.06e+05  |
```

Mesaured on an AMD 3950X @ 3.5GHz (boost disabled), compiled with GCC 8.5.

Known concerns:
- Only new-ish GCC versions benefit. In theory, this was added in GCC 6, but 8.3 is buggy, and testing with 6 gave dubious results.
- No Clang version yet supports this feture enough for us to actually use it.
- AVX512 is included for completeness, but it is not clear that it is useful.
- This is not enabled for any non-x86 architectures. 
  - Arm might benefit dues to having Neon, SVE, and SVE2.
  - Others might benefit just for the effective embedding of desirable cmpiler flags into the library. 
- There is some funny business surrounding the need for `-fPIC` on the library/`-fPIE` on users of it.