### PR TITLE
Fix convolution for splines of even order.

### DIFF
--- a/include/photospline/detail/convolve.h
+++ b/include/photospline/detail/convolve.h
@@ -63,9 +63,8 @@ void splinetable<Alloc>::convolve(const uint32_t dim, const double* conv_knots, 
 	const uint32_t k = order[dim] + 1;
 	const uint32_t q = n_conv_knots - 1;
 	
+	/* Norm is Stroem, Equation 13 */
 	double norm = ((double)(factorial(q)*factorial(k-1)))/((double)factorial(k+q-1));
-	if (k % 2 != 0)
-		norm *= -1;
 	
 	std::unique_ptr<float[]> coefficients(new float[arraysize]);
 	std::fill_n(coefficients.get(),arraysize,0.f);


### PR DESCRIPTION
For even-ordered splines, the convolution code multiplies the surface by -1. The code that does this does not obviously trace back to any part of the Stroem paper and deleting it gives correct results for even-ordered splines. It did not run for odd-ordered splines (as used by IceCube) and so deleting it has no effect there.