### PR TITLE
Add support for numpy arrays to evaluate function #34

### DIFF
--- a/src/python/photosplinemodule.cpp
+++ b/src/python/photosplinemodule.cpp
@@ -605,14 +605,21 @@ pysplinetable_evaluate(pysplinetable* self, PyObject* args, PyObject* kwds){
 			arrays[i]=NULL;
 		npy_uint32 flags = 0;
 		npy_uint32 op_flags[2*ndim+1];
-		for(unsigned int i=0; i!=2*ndim; i++){
-			if (i < ndim){
-				PyObject* item=PySequence_GetItem(pyx,i);
-				arrays[i] = (PyArrayObject*)PyArray_ContiguousFromAny(item, NPY_DOUBLE, 0, INT_MAX);
-			} else {
-				PyObject* item=PySequence_GetItem(pycenters,i-ndim);
-				arrays[i] = (PyArrayObject*)PyArray_ContiguousFromAny(item, NPY_INT, 0, INT_MAX);
+		for(unsigned int i=0; i!=ndim; i++){
+			PyObject* item=PySequence_GetItem(pyx,i);
+			arrays[i] = (PyArrayObject*)PyArray_ContiguousFromAny(item, NPY_DOUBLE, 0, INT_MAX);
+			Py_DECREF(item);
+			op_flags[i] = NPY_ITER_READONLY;
+			if (arrays[i] == NULL) {
+				for (unsigned int j=0; j<i; j++)
+					Py_DECREF(arrays[i]);
+				return NULL;
 			}
+		}
+
+		for(unsigned int i=ndim; i!=2*ndim; i++){
+			PyObject* item=PySequence_GetItem(pycenters,i-ndim);
+			arrays[i] = (PyArrayObject*)PyArray_ContiguousFromAny(item, NPY_INT, 0, INT_MAX);
 			Py_DECREF(item);
 			op_flags[i] = NPY_ITER_READONLY;
 			if (arrays[i] == NULL) {

--- a/src/python/photosplinemodule.cpp
+++ b/src/python/photosplinemodule.cpp
@@ -563,10 +563,10 @@ pysplinetable_searchcenters(pysplinetable* self, PyObject* args, PyObject* kwds)
 			// create a new 1D array that shares data with the row
 			npy_intp dims[1] = {PyArray_DIM(array_out, 1)};  // length of the row
 
-			PyArrayObject* result = (PyArrayObject*)PyArray_SimpleNewFromData(1, dims, NPY_LONG, row_data);
-			arrays[ndim+i] = result;
+			PyArrayObject* row_array = (PyArrayObject*)PyArray_SimpleNewFromData(1, dims, NPY_LONG, row_data);
+			arrays[ndim+i] = row_array;
 
-			op_flags[ndim+i] = NPY_ITER_READWRITE;
+			op_flags[ndim+i] = NPY_ITER_WRITEONLY;
 		}
 		NpyIter *iter = NpyIter_MultiNew(2*ndim, arrays, flags, NPY_KEEPORDER, NPY_NO_CASTING, op_flags, NULL);
 		if (iter == NULL){
@@ -728,9 +728,7 @@ pysplinetable_evaluate(pysplinetable* self, PyObject* args, PyObject* kwds){
 			for (unsigned dim=0; dim<ndim; dim++)
 				x[dim] = *reinterpret_cast<double*>(data_ptr[dim]);
 			for (unsigned dim=0; dim<ndim; dim++)
-				centers[dim] = *reinterpret_cast<int*>(data_ptr[dim+ndim]);
-			// TODO: TK, we probably need an additional check here to return `0.`
-			// when centers are out of bounds?
+				centers[dim] = *reinterpret_cast<int*>(data_ptr[ndim+dim]);
 			*reinterpret_cast<double*>(data_ptr[2*ndim]) = self->table->ndsplineeval(x,centers,derivatives);
 		} while (iternext(iter));
 		

--- a/src/python/photosplinemodule.cpp
+++ b/src/python/photosplinemodule.cpp
@@ -579,7 +579,7 @@ pysplinetable_evaluate(pysplinetable* self, PyObject* args, PyObject* kwds){
 	
 	//unpack x and centers
 	//assume these are arbitrary sequences, not numpy arrays
-	//TODO: should be possible to make a more efficient case for numpy arrays
+#ifndef HAVE_NUMPY
 	{
 		//a small amount of evil
 		double x[ndim];
@@ -597,6 +597,69 @@ pysplinetable_evaluate(pysplinetable* self, PyObject* args, PyObject* kwds){
 		double result=self->table->ndsplineeval(x,centers,derivatives);
 		return(Py_BuildValue("d",result));
 	}
+#else
+	//optimized case for numpy arrays (or things that can be converted to them)
+	{
+		PyArrayObject* arrays[ndim+1];
+		for(unsigned int i=0; i!=ndim+1; i++)
+			arrays[i]=NULL;
+		npy_uint32 flags = 0;
+		npy_uint32 op_flags[ndim+1];
+		for(unsigned int i=0; i!=ndim; i++){
+			PyObject* item=PySequence_GetItem(pyx,i);
+			arrays[i] = (PyArrayObject*)PyArray_ContiguousFromAny(item, NPY_DOUBLE, 0, INT_MAX);
+			Py_DECREF(item);
+			op_flags[i] = NPY_ITER_READONLY;
+			if (arrays[i] == NULL) {
+				for (unsigned int j=0; j<i; j++)
+					Py_DECREF(arrays[i]);
+				return NULL;
+			}
+		}
+		
+		// allocate the output array automatically
+		arrays[ndim] = NULL;
+		op_flags[ndim] = NPY_ITER_WRITEONLY | NPY_ITER_ALLOCATE;
+		NpyIter *iter = NpyIter_MultiNew(ndim+1, arrays, flags, NPY_KEEPORDER, NPY_NO_CASTING, op_flags, NULL);
+		if (iter == NULL){
+			for (auto ptr : arrays){
+				if(ptr)
+					Py_DECREF(ptr);
+			}
+			return NULL;
+		}
+		char** data_ptr = NpyIter_GetDataPtrArray(iter);
+		NpyIter_IterNextFunc* iternext = NpyIter_GetIterNext(iter, NULL);
+		
+		double x[ndim];
+		int centers[ndim];
+		do {
+			for (unsigned dim=0; dim<ndim; dim++)
+				x[dim] = *reinterpret_cast<double*>(data_ptr[dim]);
+			if(!self->table->searchcenters(x,centers)){
+				*reinterpret_cast<double*>(data_ptr[ndim]) = 0.;
+			} else {
+				*reinterpret_cast<double*>(data_ptr[ndim]) = self->table->ndsplineeval(x,centers,derivatives);
+			}
+		} while (iternext(iter));
+		
+		// retrieve output array
+		PyArrayObject *out = NpyIter_GetOperandArray(iter)[ndim];
+		Py_INCREF(out);
+		
+		// clean up
+		for (auto ptr : arrays){
+			if(ptr)
+				Py_DECREF(ptr);
+		}
+		if (NpyIter_Deallocate(iter) != NPY_SUCCEED) {
+			Py_DECREF(out);
+			return NULL;
+		}
+		
+		return PyArray_Return(out);
+	}
+#endif
 }
 
 //attempts to do search centers and ndsplineeval in one step

--- a/src/python/photosplinemodule.cpp
+++ b/src/python/photosplinemodule.cpp
@@ -619,7 +619,7 @@ pysplinetable_evaluate(pysplinetable* self, PyObject* args, PyObject* kwds){
 
 		for(unsigned int i=ndim; i!=2*ndim; i++){
 			PyObject* item=PySequence_GetItem(pycenters,i-ndim);
-			arrays[i] = (PyArrayObject*)PyArray_ContiguousFromAny(item, NPY_INT, 0, INT_MAX);
+			arrays[i] = (PyArrayObject*)PyArray_ContiguousFromAny(item, NPY_LONG, 0, INT_MAX);
 			Py_DECREF(item);
 			op_flags[i] = NPY_ITER_READONLY;
 			if (arrays[i] == NULL) {

--- a/src/python/photosplinemodule.cpp
+++ b/src/python/photosplinemodule.cpp
@@ -505,7 +505,7 @@ pysplinetable_searchcenters(pysplinetable* self, PyObject* args, PyObject* kwds)
 	
 	//unpack x
 	//assume these are arbitrary sequences, not numpy arrays
-	//TODO: should be possible to make a more efficient case for numpy arrays
+#ifndef HAVE_NUMPY
 	{
 		//a small amount of evil
 		double x[ndim];
@@ -528,6 +528,69 @@ pysplinetable_searchcenters(pysplinetable* self, PyObject* args, PyObject* kwds)
 			PyTuple_SetItem(result,i,Py_BuildValue("i",centers[i]));
 		return(result);
 	}
+#else
+	//optimized case for numpy arrays (or things that can be converted to them)
+	{
+		PyArrayObject* arrays[ndim+1];
+		for(unsigned int i=0; i!=ndim+1; i++)
+			arrays[i]=NULL;
+		npy_uint32 flags = 0;
+		npy_uint32 op_flags[ndim+1];
+		for(unsigned int i=0; i!=ndim; i++){
+			PyObject* item=PySequence_GetItem(pyx,i);
+			arrays[i] = (PyArrayObject*)PyArray_ContiguousFromAny(item, NPY_DOUBLE, 0, INT_MAX);
+			Py_DECREF(item);
+			op_flags[i] = NPY_ITER_READONLY;
+			if (arrays[i] == NULL) {
+				for (unsigned int j=0; j<i; j++)
+					Py_DECREF(arrays[i]);
+				return NULL;
+			}
+		}
+		
+		// allocate the output array automatically
+		arrays[ndim] = NULL;
+		op_flags[ndim] = NPY_ITER_WRITEONLY | NPY_ITER_ALLOCATE;
+		NpyIter *iter = NpyIter_MultiNew(ndim+1, arrays, flags, NPY_KEEPORDER, NPY_NO_CASTING, op_flags, NULL);
+		if (iter == NULL){
+			for (auto ptr : arrays){
+				if(ptr)
+					Py_DECREF(ptr);
+			}
+			return NULL;
+		}
+		char** data_ptr = NpyIter_GetDataPtrArray(iter);
+		NpyIter_IterNextFunc* iternext = NpyIter_GetIterNext(iter, NULL);
+		
+		double x[ndim];
+		int centers[ndim];
+		do {
+			for (unsigned dim=0; dim<ndim; dim++)
+				x[dim] = *reinterpret_cast<double*>(data_ptr[dim]);
+			if(!self->table->searchcenters(x,centers)){
+				*reinterpret_cast<double*>(data_ptr[ndim]) = 0.;
+			} else {
+				*reinterpret_cast<double*>(data_ptr[ndim]) = self->table->ndsplineeval(x,centers,derivatives);
+			}
+		} while (iternext(iter));
+		
+		// retrieve output array
+		PyArrayObject *out = NpyIter_GetOperandArray(iter)[ndim];
+		Py_INCREF(out);
+		
+		// clean up
+		for (auto ptr : arrays){
+			if(ptr)
+				Py_DECREF(ptr);
+		}
+		if (NpyIter_Deallocate(iter) != NPY_SUCCEED) {
+			Py_DECREF(out);
+			return NULL;
+		}
+		
+		return PyArray_Return(out);
+	}
+#endif
 }
 
 static PyObject*

--- a/src/python/photosplinemodule.cpp
+++ b/src/python/photosplinemodule.cpp
@@ -648,8 +648,8 @@ pysplinetable_evaluate(pysplinetable* self, PyObject* args, PyObject* kwds){
 		do {
 			for (unsigned dim=0; dim<ndim; dim++)
 				x[dim] = *reinterpret_cast<double*>(data_ptr[dim]);
-			for (unsigned dim=ndim; dim<2*ndim; dim++)
-				centers[dim] = *reinterpret_cast<int*>(data_ptr[dim]);
+			for (unsigned dim=0; dim<ndim; dim++)
+				centers[dim] = *reinterpret_cast<int*>(data_ptr[dim+ndim]);
 			// TODO: TK, we probably need an additional check here to return `0.`
 			// when centers are out of bounds?
 			*reinterpret_cast<double*>(data_ptr[2*ndim]) = self->table->ndsplineeval(x,centers,derivatives);


### PR DESCRIPTION
This PR adds support for numpy arrays as arguments in `pysplinetable_searchcenters` and  `pysplinetable_evaluate` methods.
It allows us to optimize our code by reusing centers values when calling `pysplinetable_evaluate` method in our analysis, as discussed in: https://github.com/icecube/photospline/issues/34