### PR TITLE
Expose stacking constructor to Python

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -363,6 +363,11 @@ LIST (APPEND ALL_TESTS
   photospline-test-templated
 )
 
+if(PYTHON_FOUND AND NUMPY_FOUND)
+  ADD_TEST(photospline-test-pystack ${PYTHON_EXECUTABLE} ${PROJECT_SOURCE_DIR}/test/test_stack.py)
+  LIST (APPEND ALL_TESTS photospline-test-pystack)
+endif()
+
 if(BUILD_SPGLAM)
   ADD_EXECUTABLE(photospline-test-fit
     test/test_main.cpp

--- a/test/test_stack.py
+++ b/test/test_stack.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python
+
+import sys, os
+
+sys.path.append(os.getcwd())
+import numpy
+import photospline
+
+from pathlib import Path
+
+import unittest
+
+
+class StackTest(unittest.TestCase):
+    def setUp(self):
+        self.testdata = Path(__file__).parent / "test_data"
+        self.spline = photospline.SplineTable(
+            str(self.testdata / "test_spline_1d.fits")
+        )
+
+    def testStack(self):
+        spline = self.spline
+        stack = photospline.SplineTable.stack([spline] * 3, [-1, 0, 1], stackOrder=2)
+        self.assertEqual(spline.ndim, 1)
+        self.assertEqual(stack.ndim, 2)
+        self.assertEqual(stack.order, (2, 2))
+        numpy.testing.assert_equal(stack.knots[0], spline.knots[0])
+        numpy.testing.assert_equal(
+            stack.knots[1], [-3.6, -2.6, -1.6, -0.6, 0.4, 1.4, 2.4, 3.4]
+        )
+
+    def testBadArgs(self):
+        with self.assertRaises(ValueError):
+            photospline.SplineTable.stack([], [])
+        with self.assertRaises(TypeError):
+            photospline.SplineTable.stack(range(3), [])
+        with self.assertRaises(TypeError):
+            photospline.SplineTable.stack([self.spline], ["a"])
+        with self.assertRaises(TypeError):
+            photospline.SplineTable.stack([self.spline, None], [])
+        with self.assertRaises(ValueError):
+            photospline.SplineTable.stack([self.spline] * 2, [1])
+
+    def testSetup(self):
+        assert self.testdata.exists()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Expose the stacking ctor `splinetable(std::vector<splinetable<Alloc>*> tables, std::vector<double> coordinates, int stackOrder)` to Python via a class method `SplineTable.stack()`. Actually overloading the __init__ method is somewhat awkward, but could be done if harmony between the C++ and Python APIs is important. Opinions welcome!

Fixes #25.