### PR TITLE
Expose sparse NNLS to Python

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python-version }}
-      - run: pip install numpy
+      - run: pip install numpy scipy
       - run: sudo apt-get install libsuitesparse-dev libbtbb-dev liblapack-dev libcfitsio-dev libmetis-dev libgsl-dev
       - run: cmake -DPython_EXECUTABLE=$(which python) . && make && sudo make install
       - run: python -c "import photospline"
@@ -53,7 +53,7 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python-version }}
-      - run: pip install numpy
+      - run: pip install numpy scipy
       - run: brew install suite-sparse cfitsio gsl
       - run: cmake -DPython_EXECUTABLE=$(which python) . && make && make install
       - run: python -c "import photospline"
@@ -78,7 +78,7 @@ jobs:
           githubToken: ${{ github.token }}
           install: |
             apt-get update -q -y
-            apt-get install -q -y cmake clang libsuitesparse-dev libbtbb-dev liblapack-dev libcfitsio-dev libmetis-dev libgsl-dev python3-dev python3-numpy
+            apt-get install -q -y cmake clang libsuitesparse-dev libbtbb-dev liblapack-dev libcfitsio-dev libmetis-dev libgsl-dev python3-dev python3-numpy python3-scipy
           run: |
             cmake -DPython_EXECUTABLE=$(which python3) .
             make

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -394,6 +394,14 @@ if(BUILD_SPGLAM)
      WORKING_DIRECTORY ${CMAKE_BUILD_DIR}
     )
     LIST (APPEND ALL_TESTS photospline-test-pyfit)
+    if(BUILD_SPGLAM)
+      ADD_TEST(NAME photospline-test-nnls
+        COMMAND ${PYTHON_EXECUTABLE} ${PROJECT_SOURCE_DIR}/test/test_nnls.py
+        WORKING_DIRECTORY ${CMAKE_BUILD_DIR}
+      )
+      set_property(TEST photospline-test-nnls PROPERTY ENVIRONMENT PYTHONPATH=${PROJECT_BINARY_DIR})
+      LIST (APPEND ALL_TESTS photospline-test-nnls)
+    endif()
   endif()
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required (VERSION 3.1.0 FATAL_ERROR)
 cmake_policy(VERSION 3.1.0)
 
-project (photospline VERSION 2.2.1 LANGUAGES C CXX)
+project (photospline VERSION 2.3.0 LANGUAGES C CXX)
 
 SET(CMAKE_CXX_STANDARD 11)
 SET(CMAKE_C_STANDARD 99)

--- a/test/test_nnls.py
+++ b/test/test_nnls.py
@@ -6,7 +6,7 @@ import photospline
 class TestNNLS(unittest.TestCase):
     def setUp(self):
         try:
-            from scipy import sparse
+            from scipy import sparse  # type: ignore[import]
         except ImportError:
             raise unittest.SkipTest("test requires scipy")
 
@@ -18,7 +18,7 @@ class TestNNLS(unittest.TestCase):
         self.assertEqual(len(self.Asp.data), 3)
 
     def testImplementationMatchesScipy(self):
-        from scipy import optimize
+        from scipy import optimize  # type: ignore[import]
 
         np.testing.assert_allclose(
             photospline.nnls(self.Asp, self.b),

--- a/test/test_nnls.py
+++ b/test/test_nnls.py
@@ -1,0 +1,31 @@
+import unittest
+import numpy as np
+import photospline
+
+
+class TestNNLS(unittest.TestCase):
+    def setUp(self):
+        try:
+            from scipy import sparse
+        except ImportError:
+            raise unittest.SkipTest("test requires scipy")
+
+        self.A = np.array([[1, 0], [1, 0], [0, 1]])
+        self.Asp = sparse.csc_matrix(self.A)
+        self.b = np.array([2, 1, 1])
+
+    def testSparseIsSparse(self):
+        self.assertEqual(len(self.Asp.data), 3)
+
+    def testImplementationMatchesScipy(self):
+        from scipy import optimize
+
+        np.testing.assert_allclose(
+            photospline.nnls(self.Asp, self.b),
+            optimize.nnls(self.A, self.b)[0],
+            err_msg="sparse result does not aggree with dense",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/typings/photospline-stubs/__init__.pyi
+++ b/typings/photospline-stubs/__init__.pyi
@@ -1,6 +1,7 @@
-from typing import Sequence, Union, Any, overload
+from typing import Annotated, Sequence, Union, Any, overload
 from os import PathLike
 import numpy as np
+from scipy import sparse
 import numpy.typing as npt
 
 class SplineTable:
@@ -79,3 +80,14 @@ def glam_fit(
     monodim: None | int = None,
     verbose: int = 1,
 ) -> SplineTable: ...
+
+def nnls(
+    A: sparse.csc_matrix,
+    b: npt.NDArray[np.float64],
+    tolerance: float=0.,
+    min_iterations: int=0,
+    max_iterations: int=np.iinfo(np.int32).max,
+    npos: int=0,
+    normaleq: bool=False,
+    verbose: bool=False,
+) -> npt.NDArray[np.float64]: ...


### PR DESCRIPTION
There seem to be no other sparse implementations of Lawson-Hanson NNLS accessible from Python, so let's expose the one we ship in photospline.

Almost all of the new code is there to build a `cholmod_sparse` view into the supplied `scipy.sparse.csc_matrix`, which is more complicated that it should be due to `scipy.sparse`'s insistence on falling back to int32 for the column indices and row pointers of small matrices.