### PR TITLE
Ignore partially-supported knots in spacing bounds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required (VERSION 3.1.0 FATAL_ERROR)
 cmake_policy(VERSION 3.1.0)
 
-project (photospline VERSION 2.3.0 LANGUAGES C CXX)
+project (photospline VERSION 2.3.1 LANGUAGES C CXX)
 
 SET(CMAKE_CXX_STANDARD 11)
 SET(CMAKE_C_STANDARD 99)

--- a/include/photospline/detail/bspline_eval.h
+++ b/include/photospline/detail/bspline_eval.h
@@ -29,7 +29,7 @@ bool splinetable<Alloc>::searchcenters(const double* x, int* centers) const
 		}
 		
 		uint32_t min = order[i];
-		uint32_t max = nknots[i]-2;
+		uint32_t max = naxes[i];
 		double diff = x[i] - knots[i][min];
 		uint32_t hi = diff*rmin_sep[i];
 		uint32_t lo = diff*rmax_sep[i];

--- a/include/photospline/detail/convolve.h
+++ b/include/photospline/detail/convolve.h
@@ -146,7 +146,7 @@ void splinetable<Alloc>::convolve(const uint32_t dim, const double* conv_knots, 
 	}
 
 	// Update knot separations
-	dknot_bounds();
+	fill_knot_spacing_bounds();
 	
 	/*
 	 * NB: A monotonic function remains monotonic after convolution

--- a/include/photospline/detail/fit.h
+++ b/include/photospline/detail/fit.h
@@ -104,7 +104,7 @@ void splinetable<Alloc>::fit(const ::ndsparse& data,
 		std::copy(knots[i].begin(),knots[i].end(),this->knots[i]);
 		dummy_knots[i]=&this->knots[i][0];
 	}
-	dknot_bounds();
+	fill_knot_spacing_bounds();
 	//same deal for the coordinates
 	std::unique_ptr<const double*[]> dummy_coords(new const double*[ndim]);
 	for(uint32_t i=0; i<ndim; i++)

--- a/include/photospline/detail/fitsio.h
+++ b/include/photospline/detail/fitsio.h
@@ -382,7 +382,7 @@ bool splinetable<Alloc>::read_fits_core(fitsfile* fits, const std::string& fileP
 		}
 	}
 
-	dknot_bounds();
+	fill_knot_spacing_bounds();
 	
 	if(error!=0)
 		throw std::runtime_error("Error reading "+filePath+": Error "+std::to_string(error));

--- a/include/photospline/detail/permute.h
+++ b/include/photospline/detail/permute.h
@@ -84,7 +84,7 @@ void splinetable<Alloc>::permuteDimensions(const std::vector<size_t>& permutatio
 	std::copy(t_coefficients.get(),t_coefficients.get()+ncoeffs,coefficients);
 
 	// Update knot separations
-	dknot_bounds();
+	fill_knot_spacing_bounds();
 }
 	
 } //namespace photospline

--- a/include/photospline/splinetable.h
+++ b/include/photospline/splinetable.h
@@ -277,15 +277,15 @@ public:
       lastKnots[nknots[inputDim]-1]=2*lastKnots[nknots[inputDim]-2]-lastKnots[nknots[inputDim]-3];
     }
 
-    rmin_sep=allocate<double>(ndim);
-    rmax_sep=allocate<double>(ndim);
-		dknot_bounds();
-
     //set naxes
     naxes=allocate<uint64_t>(ndim);
     for(unsigned int i=0; i<inputDim; i++)
       naxes[i] = tables.front()->get_ncoeffs(i);
     naxes[inputDim]=tables.size();
+
+    rmin_sep=allocate<double>(ndim);
+    rmax_sep=allocate<double>(ndim);
+    fill_knot_spacing_bounds();
 
     //copy coefficients
     unsigned long nCoeffs=std::accumulate(naxes, naxes+ndim, 1UL, std::multiplies<uint64_t>());
@@ -856,10 +856,10 @@ private:
 	///Write to a file
 	void write_fits_core(fitsfile*) const;
 
-	void dknot_bounds() {
+	void fill_knot_spacing_bounds() {
 		for (uint32_t i = 0; i < ndim; i++) {
 			uint32_t min = order[i];
-			uint32_t max = nknots[i]-2;
+			uint32_t max = naxes[i];
 			double mini = DBL_MAX;
 			double maxi = 0;
 			for (uint32_t j = min; j < max; j++) {


### PR DESCRIPTION
Fix a regression after #41 for splines where the first or last `order` knots are identical. These are perfectly valid, but led `rmin_sep` to become infinite, and `searchcenters()` to get stuck in an infinite loop.