### PR TITLE
Add pickle support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,7 +55,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - run: pip install numpy scipy
       - run: brew install suite-sparse cfitsio gsl
-      - run: cmake -DPython_EXECUTABLE=$(which python) . && make
+      - run: cmake -DPython_EXECUTABLE=$(which python) -DCMAKE_INSTALL_PREFIX=install . && make install
       - run: python -c "import photospline"
       - run: ctest --output-on-failure
   architecture-zoo:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,8 +45,8 @@ jobs:
       fail-fast: false
       matrix:
         python-version:
-          - 3.8
           - 3.9
+          - 3.12
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,7 +55,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - run: pip install numpy scipy
       - run: brew install suite-sparse cfitsio gsl
-      - run: cmake -DPython_EXECUTABLE=$(which python) . && make && make install
+      - run: cmake -DPython_EXECUTABLE=$(which python) . && make
       - run: python -c "import photospline"
       - run: ctest --output-on-failure
   architecture-zoo:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required (VERSION 3.1.0 FATAL_ERROR)
 cmake_policy(VERSION 3.1.0)
 
-project (photospline VERSION 2.3.1 LANGUAGES C CXX)
+project (photospline VERSION 2.4.0 LANGUAGES C CXX)
 
 SET(CMAKE_CXX_STANDARD 11)
 SET(CMAKE_C_STANDARD 99)
@@ -374,6 +374,9 @@ if(PYTHON_FOUND AND NUMPY_FOUND)
   ADD_TEST(photospline-test-pyeval ${PYTHON_EXECUTABLE} ${PROJECT_SOURCE_DIR}/test/test_eval.py)
   set_property(TEST photospline-test-pyeval PROPERTY ENVIRONMENT PYTHONPATH=${PROJECT_BINARY_DIR})
   LIST (APPEND ALL_TESTS photospline-test-pyeval)
+  ADD_TEST(photospline-test-pickle ${PYTHON_EXECUTABLE} ${PROJECT_SOURCE_DIR}/test/test_pickle.py)
+  set_property(TEST photospline-test-pickle PROPERTY ENVIRONMENT PYTHONPATH=${PROJECT_BINARY_DIR})
+  LIST (APPEND ALL_TESTS photospline-test-pickle)
 endif()
 
 if(BUILD_SPGLAM)

--- a/test/test_pickle.py
+++ b/test/test_pickle.py
@@ -1,0 +1,26 @@
+#!/usr/bin/env python
+
+import pickle
+import unittest
+import photospline
+
+import numpy as np
+
+from pathlib import Path
+
+
+class TestEvaluation(unittest.TestCase):
+    def setUp(self):
+        self.testdata = Path(__file__).parent / "test_data"
+        self.spline = photospline.SplineTable(self.testdata / "test_spline_4d.fits")
+        extents = np.array(self.spline.extents)
+        loc = extents[:, :1]
+        scale = np.diff(extents, axis=1)
+        self.x = (np.random.uniform(0, 1, size=(self.spline.ndim, 10)) + loc) * scale
+
+    def test_pickle(self):
+        restored = pickle.loads(pickle.dumps(self.spline))
+        np.testing.assert_allclose(self.spline.evaluate_simple(self.x), restored.evaluate_simple(self.x), rtol=0, atol=0)
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
It is sometimes useful to pass (small) spline tables between processes using pickle serialization. Add a simple `__getstate__`/`__setstate__` pair that writes to and reads from a byte string. Along the way, fix up `pysplinetableType`'s `tp_name` to match the name actually exposed to Python.