### PR TITLE
Fix uint_32 overflow

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,7 @@ else()
 endif()
 
 
-project (photospline VERSION 2.4.0 LANGUAGES C CXX)
+project (photospline VERSION 2.4.1 LANGUAGES C CXX)
 
 SET(CMAKE_CXX_STANDARD 11)
 SET(CMAKE_C_STANDARD 99)

--- a/include/photospline/detail/bspline_eval.h
+++ b/include/photospline/detail/bspline_eval.h
@@ -3,6 +3,7 @@
 
 #include <random>
 #include <chrono>
+#include <limits>
 
 namespace photospline{
 	
@@ -31,8 +32,9 @@ bool splinetable<Alloc>::searchcenters(const double* x, int* centers) const
 		uint32_t min = order[i];
 		uint32_t max = naxes[i];
 		double diff = x[i] - knots[i][min];
-		uint32_t hi = diff*rmin_sep[i];
-		uint32_t lo = diff*rmax_sep[i];
+		uint32_t hi = (std::numeric_limits<uint32_t>::max() < diff*rmin_sep[i] ?
+									 std::numeric_limits<uint32_t>::max() : static_cast<uint32_t>(diff*rmin_sep[i]));
+		uint32_t lo = static_cast<uint32_t>(diff*rmax_sep[i]);
 		if (hi < hi+min+1 && hi+min+1 < max) max = hi+min+1;
 		min += lo;
 		do {

--- a/include/photospline/detail/bspline_eval.h
+++ b/include/photospline/detail/bspline_eval.h
@@ -33,7 +33,7 @@ bool splinetable<Alloc>::searchcenters(const double* x, int* centers) const
 		double diff = x[i] - knots[i][min];
 		uint32_t hi = diff*rmin_sep[i];
 		uint32_t lo = diff*rmax_sep[i];
-		if (hi+min+1 < max) max = hi+min+1;
+		if (hi < hi+min+1 && hi+min+1 < max) max = hi+min+1;
 		min += lo;
 		do {
 			centers[i] = (max+min)/2;


### PR DESCRIPTION
Only assign to the upper bound when there's no wraparound. Previously would cause an infinite loop in a case where `hi` hit the uint_32 max.